### PR TITLE
pytest-remotedata 0.4.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2011-2017, Astropy Developers
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of the Astropy Team nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptols
+    - setuptools
     - wheel
     - setuptools_scm
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,14 +18,25 @@ requirements:
   host:
     - python
     - pip
+    - setuptols
+    - wheel
+    - setuptools_scm
   run:
     - python
-    - pytest >=3.1
-    - six
+    - pytest >=4.6
+    - packaging
 
 test:
+  source_files:
+    - tests/
   imports:
     - pytest_remotedata
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest tests -vv
 
 about:
   home: https://github.com/astropy/pytest-remotedata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,9 @@ test:
 
 about:
   home: https://github.com/astropy/pytest-remotedata
-  license: BSD
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
   summary: 'Pytest plugin for controlling remote data access'
   description: |
     This package provides a plugin for the pytest framework that allows

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pytest-remotedata" %}
 {% set version = "0.3.2" %}
-{% set git_url = "https://github.com/astropy/pytest-remotedata" %}
 {% set sha256 = "e20c58d4b7c359c4975dc3c3d3d67be0905180d2368be0be3ae09b15a136cfc0" %}
 
 package:
@@ -30,15 +29,15 @@ test:
     - pytest_remotedata
 
 about:
-  home: {{ git_url }}
+  home: https://github.com/astropy/pytest-remotedata
   license: BSD
   summary: 'Pytest plugin for controlling remote data access'
   description: |
     This package provides a plugin for the pytest framework that allows
     developers to control unit tests that require access to data from the
     internet.
-  doc_url: {{ git_url }}
-  dev_url: {{ git_url }}
+  doc_url: https://github.com/astropy/pytest-remotedata
+  dev_url: https://github.com/astropy/pytest-remotedata
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest tests -vv
+    - pytest tests -vv -k "not (test_block_internet_connection or test_block_internet_connection_internet_off or test_local_config)"
 
 about:
   home: https://github.com/astropy/pytest-remotedata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 05c08bf638cdd1ed66eb01738a1647c3c714737c3ec3abe009d2c1f793b4bb59
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python -m pip install . --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pytest-remotedata" %}
-{% set version = "0.3.2" %}
-{% set sha256 = "e20c58d4b7c359c4975dc3c3d3d67be0905180d2368be0be3ae09b15a136cfc0" %}
+{% set version = "0.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 05c08bf638cdd1ed66eb01738a1647c3c714737c3ec3abe009d2c1f793b4bb59
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6879](https://anaconda.atlassian.net/browse/PKG-6879)
- [Upstream repository](https://github.com/astropy/pytest-remotedata/tree/v0.4.1)
- [Upstream changelog/diff](https://github.com/astropy/pytest-remotedata/blob/v0.4.1/CHANGES.rst)
- Relevant dependency PRs:
  - Dependency for `pytest-astropy`

### Explanation of changes:

- Build for python 3.13
- Update version
- Update dependencies
- Add upstream tests
- Linter fixes

[PKG-6876]: https://anaconda.atlassian.net/browse/PKG-6876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-6879]: https://anaconda.atlassian.net/browse/PKG-6879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ